### PR TITLE
Reset `Container` to a clean state

### DIFF
--- a/tests/test_configure.py
+++ b/tests/test_configure.py
@@ -17,6 +17,7 @@ def test_configure():
     assert Container.get().bindings[int] == str
     with raises(InjectException):
         configure(provider=provider)
+    Container.clear()
 
 
 def test_configure_after_clear():


### PR DESCRIPTION
The PR aims to improve the reliability of the test `test_configure` by resetting `Container` to a clean state by calling method`clear`.

The test can fail in the following way if `Container` is not in a clean state:
```
>               raise InjectException(msg="Already injected")
E               pythondi.InjectException: Already injected
```