### PR TITLE
Clean a polluted state to fix a flaky test.

### DIFF
--- a/tests/test_configure.py
+++ b/tests/test_configure.py
@@ -1,4 +1,5 @@
 from pytest import raises
+from pythondi import Container
 
 from pythondi import (
     configure,
@@ -10,6 +11,7 @@ from pythondi import (
 
 
 def test_configure():
+    Container.clear()
     provider = Provider()
     provider.bind(int, str)
     configure(provider=provider)


### PR DESCRIPTION
# What is the purpose of the change
This PR is to fix a flaky test `tests/test_configure.py::test_configure`, which can fail after running ` tests/test_container.py::test_set`.

# Reproduce the test failure
Run the following command:
```
python -m pytest tests/test_container.py::test_set tests/test_configure.py::test_configure
```
# Expected Result
 `tests/test_configure.py::test_configure` pass after running ` tests/test_container.py::test_set`.

# Actual Result
```
provider = <pythondi.Provider object at 0x7fa83b0b46d0>

    def configure(provider: Provider) -> Optional[NoReturn]:
        """Configure provider to container"""
        with _LOCK:
            if Container.get():
>               raise InjectException(msg="Already injected")
E               pythondi.InjectException: Already injected

pythondi/__init__.py:76: InjectException
```
# Why it fails
The container is polluted after ` tests/test_container.py::test_set` is run.

# Fix
Clear the container at the beginning of `tests/test_configure.py::test_configure`.